### PR TITLE
Update ember-cli-htmlbars to 4.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5460,9 +5460,9 @@
       "dev": true
     },
     "ember-cli-htmlbars": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.0.4.tgz",
-      "integrity": "sha512-hBcD3buJ3I8kxzT6bQVArnFZLXwV5Lo63Xv+2aoDVDKbYwpcL1wv+idmefFT00W/6nKKpFZTFrUjo1F1v+iwjg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.0.5.tgz",
+      "integrity": "sha512-/zJKzP7RVNnnlYwtliyLsr174wBLcFMJUIOvy0mGnb+optwDJpgCdMzSYEjy/myoXDWgS/6cpLVLneFZ4tYm9Q==",
       "dev": true,
       "requires": {
         "@ember/edition-utils": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-babel": "^7.11.1",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^4.0.0",
+    "ember-cli-htmlbars": "^4.0.5",
     "ember-cli-htmlbars-inline-precompile": "^3.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-sri": "^2.1.1",


### PR DESCRIPTION
Fixes issue with `ember build`:

```
~/sandbox/-ember-engines-duplicate-plugin-error update-htmlbars
❯ ember b
DEPRECATION: ember-cli-htmlbars-inline-precompile is no longer needed with ember-cli-htmlbars versions 4.0.0 and higher, please remove it from `/Users/rjackson/sandbox/-ember-engines-duplicate-plugin-error/package.json`
Environment: development
cleaning up...
Built project successfully. Stored in "dist/".
```